### PR TITLE
Update diffractive splitter leaderboard with corrected eval metric

### DIFF
--- a/challenges/diffractive_splitter/leaderboard.txt
+++ b/challenges/diffractive_splitter/leaderboard.txt
@@ -1,3 +1,3 @@
-path=challenges/diffractive_splitter/solutions/230901_lighttrans_00.csv, eval_metric=0.029919454409754343, minimum_width=2.0, minimum_spacing=2.0, binarization_degree=1.0
-path=challenges/diffractive_splitter/solutions/230901_lighttrans_01.csv, eval_metric=0.055865770909960887, minimum_width=2.0, minimum_spacing=2.0, binarization_degree=1.0
-path=challenges/diffractive_splitter/solutions/230901_lighttrans_02.csv, eval_metric=0.06400620066898059, minimum_width=9.0, minimum_spacing=9.0, binarization_degree=1.0
+path=challenges/diffractive_splitter/solutions/230901_lighttrans_00.csv, eval_metric=0.1363137188357655, minimum_width=2.0, minimum_spacing=2.0, binarization_degree=1.0
+path=challenges/diffractive_splitter/solutions/230901_lighttrans_01.csv, eval_metric=0.35730907781874044, minimum_width=2.0, minimum_spacing=2.0, binarization_degree=1.0
+path=challenges/diffractive_splitter/solutions/230901_lighttrans_02.csv, eval_metric=0.4348705928158037, minimum_width=9.0, minimum_spacing=9.0, binarization_degree=1.0


### PR DESCRIPTION
The splitter eval metric was incorrectly calculated. This was fixed inhttps://github.com/invrs-io/gym/pull/137, but now the diffractive splitter leaderboard must be updated.